### PR TITLE
Set footnote number to match AIAA guidelines

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -197,6 +197,9 @@
   show: columns.with(1, gutter: 0pt)
   set par(justify: true, first-line-indent: 1.5em, spacing: 0.65em)
 
+  // Configure footnote numbering
+  set footnote(numbering: "*")
+
   // Display abstract and index terms.
   if abstract != none [
     #text(10pt, weight: "bold",


### PR DESCRIPTION
As per guidelines in template:
Numbered footnotes as formatted automatically in the template are acceptable, but superscript symbols are the preferred AIAA style, in the sequence, \*, \†, \‡, \§, \¶, \#, \*\*. \†\†, \‡\‡, \§\§, etc.

Typst documentation says that the * numbering:
The * character means that symbols should be used to count, in the order of *, †, ‡, §, ¶, ‖. If there are more than six items, the number is represented using repeated symbols.

There is a discrepancy with the ‖ symbol, not sure how to resolve that.